### PR TITLE
Fix duplicate msgid 'lang' for zh_TW.po

### DIFF
--- a/zh_TW.po
+++ b/zh_TW.po
@@ -24,9 +24,6 @@ msgstr "繁體中文"
 msgid "UTF-8"
 msgstr "UTF-8"
 
-msgid "lang"
-msgstr "繁体中文"
-
 msgid "Typecho 安装程序"
 msgstr "Typecho 安裝程式"
 


### PR DESCRIPTION
duplicate of msgid 'lang' causing fatal error while compiling using 'gettext'